### PR TITLE
Use Node.js versions 18.x and 20.x for workflows

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR updates the versions of Node.js used during CI runs.